### PR TITLE
Bump Okio

### DIFF
--- a/android-whitelist.json
+++ b/android-whitelist.json
@@ -1382,9 +1382,15 @@
       "version": "2\\.6\\.4"
     },
     {
+      "expires": "2024-03-31",
       "group": "com\\.squareup\\.okio",
       "name": "okio",
       "version": "1\\.14\\.0"
+    },
+    {
+      "group": "com\\.squareup\\.okio",
+      "name": "okio",
+      "version": "2\\.8\\.0"
     },
     {
       "group": "com\\.squareup\\.retrofit2",


### PR DESCRIPTION
# Descripción
Bump Okio as part of OkHttp3 Migration. 

Se reportaron problemas al forzar OkHttp 4.9.3 y utilizar Okio 1.+, ya que esto fuerza por transitiva Okio 2.8.0 

# Ticket ID
- - #....

    Para más información visitar [Wiki.](https://sites.google.com/mercadolibre.com/mobile/arquitectura/allowlist) 

## En qué apps impacta mi dependencia
- [ ] Mercado Libre
- [ ] Mercado Pago
- [ ] SmartPOS
- [ ] Alicia: Flex / Logistics
- [ ] WMS
- [ ] Meli Store